### PR TITLE
populations + getindex/iteration support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Wiktor Phillips <wsphillips@gmail.com>"]
 version = "0.0.4"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/demo/STGnetwork.jl
+++ b/demo/STGnetwork.jl
@@ -45,15 +45,18 @@ LP # display
 
 PY # display
 
-topology = [Synapse(ABPD => LP, Glut(30nS), EGlut),
-            Synapse(ABPD => LP, Chol(30nS), EChol),
-            Synapse(ABPD => PY, Glut(10nS), EGlut),
-            Synapse(ABPD => PY, Chol(3nS), EChol),
-            Synapse(LP   => ABPD, Glut(30nS), EGlut),
-            Synapse(LP   => PY, Glut(1nS), EGlut),
-            Synapse(PY   => LP, Glut(30nS), EGlut)];
+topology = NetworkTopology([ABPD, LP, PY], [Glut, Chol]);
+reversal_map = Dict([Glut => EGlut, Chol => EChol])
 
-network = NeuronalNetworkSystem(topology)
+topology[ABPD, LP] = Glut(30nS)
+topology[ABPD, LP] = Chol(30nS)
+topology[ABPD, PY] = Glut(10nS)
+topology[ABPD, PY] = Chol(3nS)
+topology[LP, ABPD] = Glut(30nS)
+topology[LP, PY] = Glut(1nS)
+topology[PY, LP] = Glut(30nS)
+
+network = NeuronalNetworkSystem(topology, reversal_map)
 t = 10000
 sim = Simulation(network, time = t*ms);
 solution = solve(sim, RadauIIA5(), reltol=1e-9, abstol=1e-9);

--- a/demo/pinskyrinzel.jl
+++ b/demo/pinskyrinzel.jl
@@ -99,8 +99,8 @@ dumb_Eleak = EquilibriumPotential(Leak, 20mV)
 
 ESyn = EquilibriumPotential(NMDA, 60mV, name = :syn)
 topology = NetworkTopology([dummy, mcneuron], [NMDAChan(2µS)]);
-add_synapse!(topology, dummy, mcneuron.dendrite, NMDAChan)
-revmap = Dict([NMDAChan => ESyn])
+topology[dummy, mcneuron.dendrite] = NMDAChan
+revmap = [NMDAChan => ESyn]
 network = NeuronalNetworkSystem(topology, revmap)
 
 prob = Simulation(network, time=5000ms)

--- a/demo/pinskyrinzel.jl
+++ b/demo/pinskyrinzel.jl
@@ -7,10 +7,10 @@ import Unitful: µF, pA, µA, nA, µS
 
 @named calcium_conversion = ODESystem([D(Caᵢ) ~ -ϕ*ICa - β*Caᵢ]);
 
-reversals = Equilibria(Pair[Sodium    =>  120.0mV,
-                            Potassium =>  -15.0mV,
-                            Leak      =>    0.0mV,
-                            Calcium   =>  140.0mV]);
+reversals = Equilibria([Sodium    =>  120.0mV,
+                        Potassium =>  -15.0mV,
+                        Leak      =>    0.0mV,
+                        Calcium   =>  140.0mV]);
 
 capacitance = 3.0µF/cm^2
 gc_val = 2.1mS/cm^2

--- a/demo/simplesynapse.jl
+++ b/demo/simplesynapse.jl
@@ -45,7 +45,7 @@ EGlut = Equilibrium(Cation, 0mV, name = :Glut)
 @named Glut = SynapticChannel(Cation, [syn_kinetics]; max_s = 30nS);
 
 topology = NetworkTopology([neuron1, neuron2], [Glut]);
-add_synapse!(topology, neuron1, neuron2, Glut)
+topology[neuron1, neuron2] = Glut
 reversal_map = Dict([Glut => EGlut])
 
 @named net = NeuronalNetworkSystem(topology, reversal_map)

--- a/docs/src/core/networks.md
+++ b/docs/src/core/networks.md
@@ -2,5 +2,6 @@
 
 ## [NeuronalNetworkSystem](@id networks)
 ```@docs
+Population
 NeuronalNetworkSystem
 ```

--- a/src/Conductor.jl
+++ b/src/Conductor.jl
@@ -1,6 +1,7 @@
 module Conductor
 using DocStringExtensions
 using Graphs
+using Distributions
 using SparseArrays
 using ModelingToolkit,
       Unitful,

--- a/src/Conductor.jl
+++ b/src/Conductor.jl
@@ -64,7 +64,7 @@ export Gate, SimpleGate, AlphaBeta, SteadyStateTau, SteadyState, ConstantValue, 
 export EquilibriumPotential, Equilibrium, Equilibria, MembranePotential, IonCurrent,
        IonConcentration, Concentration, ExtrinsicPotential, Instrinsic, Extrinsic
 
-export MultiCompartmentTopology, NetworkTopology, add_synapse!, add_layer!
+export MultiCompartmentTopology, NetworkTopology, Population, add_synapse!, add_layer!
 
 export AuxConversion, D
 export Simulation
@@ -100,5 +100,5 @@ include("compartment.jl")
 include("multicompartment.jl")
 include("network.jl")
 include("simulation.jl")
-
+include("populations.jl")
 end # module

--- a/src/compartment.jl
+++ b/src/compartment.jl
@@ -279,6 +279,16 @@ function Base.:(==)(sys1::AbstractCompartmentSystem, sys2::AbstractCompartmentSy
     all(s1 == s2 for (s1, s2) in zip(get_systems(sys1), get_systems(sys2)))
 end
 
+Base.eltype(::CompartmentSystem) = CompartmentSystem
+Base.length(::CompartmentSystem) = 1
+Base.iterate(comp::CompartmentSystem, state=1) = state > 1 ? nothing : (comp, state+1)
+Base.iterate(rev_comp::Iterators.Reverse{CompartmentSystem}, state=1) = state < 1 ? nothing : (rev_comp, state-1)
+Base.getindex(comp::CompartmentSystem, i::Int) = i == 1 ? comp : throw(BoundsError(P, i))
+Base.firstindex(comp::CompartmentSystem) = 1
+Base.lastindex(comp::CompartmentSystem) = 1
+Base.getindex(comp::CompartmentSystem, i::Number) = comp[convert(Int, i)]
+Base.getindex(comp::CompartmentSystem, I) = [comp[i] for i in I]
+
 function Base.convert(::Type{ODESystem}, compartment::CompartmentSystem)
 
     dvs = get_states(compartment)

--- a/src/conductance.jl
+++ b/src/conductance.jl
@@ -299,7 +299,7 @@ end
 
 function (cond::AbstractConductanceSystem)(gbar_val::Real)
     gbar_sym = setdefault(get_gbar(cond), gbar_val)
-    newcond = @set cond.defaults = Dict(get_defaults(cond)..., gbar_sym => gbar_val)
+    newcond =  ConductanceSystem(cond; gbar = gbar_sym, defaults = Dict(get_defaults(cond)..., gbar_sym => gbar_val))
     return newcond
 end
 

--- a/src/conductance.jl
+++ b/src/conductance.jl
@@ -214,6 +214,8 @@ function IonChannel(ion::IonSpecies,
 
     @variables g(t)
     g = setmetadata(g, ConductorUnits, mS/cm^2)
+    gbar = setmetadata(gbar, ConductorUnits, mS/cm^2)
+
     ConductanceSystem(g, ion, gate_vars; gbar = gbar, name = name, defaults = defaults, 
                       extensions = extensions)
 end

--- a/src/multicompartment.jl
+++ b/src/multicompartment.jl
@@ -141,6 +141,31 @@ end
 
 hasparent(x::MultiCompartmentSystem) = false
 
+Base.eltype(::MultiCompartmentSystem) = CompartmentSystem
+Base.length(M::MultiCompartmentSystem) = length(get_compartments(M))
+
+function Base.iterate(M::MultiCompartmentSystem, state=1)
+    state > length(M) && return nothing
+    return (get_compartments(M)[state], state+1)
+end
+
+function Base.iterate(rM::Iterators.Reverse{MultiCompartmentSystem}, state=length(rM.itr))
+    state < 1 && return nothing
+    mc = rM.itr
+    return (get_compartments(mc)[state], state-1)
+end
+
+function Base.getindex(M::MultiCompartmentSystem, i; namespace = true)
+    if namespace
+        return getproperty(M, nameof(get_compartments(M)[i]))
+    else
+        return get_compartments(M)[i]
+    end
+end
+
+Base.firstindex(M::MultiCompartmentSystem) = 1
+Base.lastindex(M::MultiCompartmentSystem) = length(M)
+
 function Base.convert(::Type{ODESystem}, mcsys::MultiCompartmentSystem)
     dvs = get_states(mcsys)
     ps  = get_ps(mcsys)

--- a/src/network.jl
+++ b/src/network.jl
@@ -149,7 +149,8 @@ function NeuronalNetworkSystem(
     topology, reversal_map,
     extensions::Vector{<:AbstractTimeDependentSystem} = AbstractTimeDependentSystem[];
     defaults = Dict(), name::Symbol = Base.gensym(:Network))
-
+    
+    reversal_map = reversal_map isa AbstractDict ? reversal_map : Dict(reversal_map)
     eqs, dvs, ps, observed = Equation[], Num[], Num[], Equation[]
     voltage_fwds = Set{Equation}()
     multigraph = graph(topology)
@@ -183,6 +184,7 @@ function NeuronalNetworkSystem(
                 class_copies = [] # clone the synapse model for each presynaptic compartment
                 for (x,y) in zip(pre_compartments, weights)
                     class_copy = ConductanceSystem(synaptic_class, subscriptions = [x],
+                                                   gbar = y,
                                                    name = namegen(nameof(synaptic_class)),
                                                    defaults = Dict(y => getdefault(y)))
                     push!(class_copies, class_copy)

--- a/src/network.jl
+++ b/src/network.jl
@@ -233,7 +233,7 @@ function Base.iterate(ns::NeuronalNetworkSystem, state=1)
     return (neurons(get_topology(ns))[state], state+1)
 end
 
-function Base.iterate(rev_ns::Iterators.Reverse{NetworkTopology}, state=length(rev_ns.itr))
+function Base.iterate(rev_ns::Iterators.Reverse{NeuronalNetworkSystem}, state=length(rev_ns.itr))
     state < 1 && return nothing
     ns = rev_ns.itr
     return (neurons(get_topology(ns))[state], state-1)

--- a/src/populations.jl
+++ b/src/populations.jl
@@ -1,38 +1,91 @@
+"""
+$(TYPEDEF)
 
+An iterable population (or small group) of neurons.
+
+A `Population` is a lazy representation of neurons templated from a single model prototype.
+Iterating over a `Population` returns up to _n_ uniquely-named copies of the prototype that
+are serially numbered and, optionally, namespaced. Parameter values of the replicate neurons
+can be individually defined by indexed assignment, or applied to the entire group via
+distributions.
+
+$(FIELDS)
+"""
 struct Population{T<:AbstractCompartmentSystem}
-    "The number of neurons in the population." 
-    N::Int
     "The base neuron model."
     proto::T
+    "The number of neurons in the population." 
+    n::Int
     "Name of the population."
     popname::Symbol
+    "Population defaults"
+    defs::Vector{Dict{Num, Any}}
 end
 
-Base.nameof(P::Population) = getfield(P, :popname)
-Base.eltype(::Population{T}) where {T} = T
-Base.length(P::Population) = getfield(P, :N) 
+function Population(neuron, n; name = Symbol(""))
+    Population(neuron, n, name, [Dict{Num, Any}() for _ in 1:n])
+end
 
-function Base.iterate(P::Population, state=1)
-    state > P.N && return nothing
-    neuron = MTK.rename(P.proto, Symbol(nameof(P), '₊', nameof(P.proto), '_', state))
+Base.nameof(p::Population) = getfield(p, :popname)
+Base.eltype(::Population{T}) where {T} = T
+Base.length(p::Population) = getfield(p, :n) 
+prototype(p::Population) = getfield(p, :proto)
+
+function Base.iterate(p::Population{T}, state=1) where {T}
+    state > length(p) && return nothing
+    new_name = Symbol(nameof(p), '₊', nameof(prototype(p)), '_', state)
+    neuron = T(prototype(p); name = new_name, defaults = p.defs[state])
     return (neuron, state+1)
 end
 
-function Base.iterate(rP::Iterators.Reverse{Population{T}}, state=rP.itr.N) where {T<:AbstractCompartmentSystem}
+function Base.iterate(rP::Iterators.Reverse{Population{T}}, state=length(rP.itr)) where {T<:AbstractCompartmentSystem}
     state < 1 && return nothing
     pop = rP.itr
-    neuron = MTK.rename(pop.proto, Symbol(nameof(pop), '₊', nameof(pop.proto), '_', state))
+    new_name = Symbol(nameof(pop), '₊', nameof(prototype(pop)), '_', state)
+    neuron = T(prototype(p); name = new_name, defaults = p.defs[state])
     return (neuron, state-1)
 end
 
-function Base.getindex(P::Population, i::Int)
-    1 <= i <= P.N || throw(BoundsError(P, i))
-    return MTK.rename(P.proto, Symbol(nameof(P), '₊', nameof(P.proto), '_', i))
+function Base.getindex(p::Population, i::Int)
+    1 <= i <= length(p) || throw(BoundsError(p, i))
+    return MTK.rename(prototype(p), Symbol(nameof(p), '₊', nameof(prototype(p)), '_', i))
 end
 
-Base.firstindex(P::Population) = 1
-Base.lastindex(P::Population) = length(P)
-Base.getindex(P::Population, i::Number) = P[convert(Int, i)]
-Base.getindex(P::Population, I) = [P[i] for i in I]
+Base.firstindex(p::Population) = 1
+Base.lastindex(p::Population) = length(p)
+Base.getindex(p::Population, i::Number) = p[convert(Int, i)]
+Base.getindex(p::Population, I) = [p[i] for i in I]
 
+function (pop::Population)(p::Pair{Num,D}) where {D<:Distribution}
+    new_defs = [Dict{Num, Any}() for _ in 1:length(pop)]
+    for neuron_defs in new_defs
+        push!(neuron_defs, p.first => rand(p.second))
+    end
+    return @set pop.defs = merge.(pop.defs, new_defs)
+end
+
+function (pop::Population)(p::Pair{Num,Q}) where {Q<:Quantity}
+    var, quant = p.first, p.second
+    cunits = hasmetadata(var, ConductorUnits) ? getmetadata(var, ConductorUnits) : nothing
+    isnothing(cunits) && throw("Units do not match.")
+    val = ustrip(Float64, cunits, quant)
+    new_defs = [Dict{Num, Any}() for _ in 1:length(pop)]
+    for neuron_defs in new_defs
+        push!(neuron_defs, var => val)
+    end
+    return @set pop.defs = merge.(pop.defs, new_defs)
+end
+
+function Base.setindex!(pop::Population, p::Pair{Num,D}, i::Int) where {D<:Distribution}
+    var, dist = p.first, p.second
+    push!(pop.defs[i], var => rand(dist))
+end
+
+function Base.setindex!(pop::Population, p::Pair{Num,Q}, i::Int) where {Q<:Quantity}
+    var, quant = p.first, p.second
+    cunits = hasmetadata(var, ConductorUnits) ? getmetadata(var, ConductorUnits) : nothing
+    isnothing(cunits) && throw("Units do not match.")
+    val = ustrip(Float64, cunits, quant)
+    push!(pop.defs[i], var => val)   
+end
 

--- a/src/populations.jl
+++ b/src/populations.jl
@@ -1,0 +1,38 @@
+
+struct Population{T<:AbstractCompartmentSystem}
+    "The number of neurons in the population." 
+    N::Int
+    "The base neuron model."
+    proto::T
+    "Name of the population."
+    popname::Symbol
+end
+
+Base.nameof(P::Population) = getfield(P, :popname)
+Base.eltype(::Population{T}) where {T} = T
+Base.length(P::Population) = getfield(P, :N) 
+
+function Base.iterate(P::Population, state=1)
+    state > P.N && return nothing
+    neuron = MTK.rename(P.proto, Symbol(nameof(P), '₊', nameof(P.proto), '_', state))
+    return (neuron, state+1)
+end
+
+function Base.iterate(rP::Iterators.Reverse{Population{T}}, state=rP.itr.N) where {T<:AbstractCompartmentSystem}
+    state < 1 && return nothing
+    pop = rP.itr
+    neuron = MTK.rename(pop.proto, Symbol(nameof(pop), '₊', nameof(pop.proto), '_', state))
+    return (neuron, state-1)
+end
+
+function Base.getindex(P::Population, i::Int)
+    1 <= i <= P.N || throw(BoundsError(P, i))
+    return MTK.rename(P.proto, Symbol(nameof(P), '₊', nameof(P.proto), '_', i))
+end
+
+Base.firstindex(P::Population) = 1
+Base.lastindex(P::Population) = length(P)
+Base.getindex(P::Population, i::Number) = P[convert(Int, i)]
+Base.getindex(P::Population, I) = [P[i] for i in I]
+
+

--- a/src/populations.jl
+++ b/src/populations.jl
@@ -20,10 +20,12 @@ struct Population{T<:AbstractCompartmentSystem}
     popname::Symbol
     "Population defaults"
     defs::Vector{Dict{Num, Any}}
+    "Stimuli applied to select neurons."
+    stimuli::Vector{Vector{Equation}}
 end
 
 function Population(neuron, n; name = Symbol(""))
-    Population(neuron, n, name, [Dict{Num, Any}() for _ in 1:n])
+    Population(neuron, n, name, [Dict{Num, Any}() for _ in 1:n], [Equation[] for _ in 1:n])
 end
 
 Base.nameof(p::Population) = getfield(p, :popname)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -105,6 +105,7 @@ struct MembranePotential
    
         ret = setmetadata.(ret, PrimitiveSource, source)
         ret = setmetadata.(ret, MembranePotential, true)
+        ret = setmetadata.(ret, ConductorUnits, mV)
         return ret
     end
 end

--- a/src/stimulus.jl
+++ b/src/stimulus.jl
@@ -1,0 +1,18 @@
+
+abstract type AbstractStimulus end
+
+struct Stimulator{T<:AbstractStimulus}
+    channels::Vector{T} 
+end
+
+struct PulseTrain{T<:Real} <: AbstractStimulus
+    interval::T
+    duration::T
+    delay::T
+    npulses::Int
+    offset::T
+    amplitude::T
+end
+
+struct Waveform{T<:Real} <: AbstractStimulus end
+


### PR DESCRIPTION
`Population` allows creating arbitrary numbers of neurons from a prototype/template using the Base.Iterators interface.

This PR will also implement iteration and indexing on `MultiCompartmentSystems` (to index subcompartments versus calling by name with `getproperty`) and the same for `NetworkTopology` and `NeuronalNetworkSystem`.